### PR TITLE
log4j  CVE-2021-44228 vulnerability setup

### DIFF
--- a/services/tools.descartes.teastore.webui/pom.xml
+++ b/services/tools.descartes.teastore.webui/pom.xml
@@ -12,7 +12,13 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
-
+		<dependency>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j</artifactId>
+		    <version>2.14.1</version>
+		    <type>pom</type>
+		</dependency>
+		
 		<!-- Internal Dependencies -->
 		<dependency>
 			<groupId>tools.descartes.teastore</groupId>

--- a/services/tools.descartes.teastore.webui/src/main/java/tools/descartes/teastore/webui/servlet/LoginActionServlet.java
+++ b/services/tools.descartes.teastore.webui/src/main/java/tools/descartes/teastore/webui/servlet/LoginActionServlet.java
@@ -35,6 +35,9 @@ import org.apache.log4j.LogManager;
 @WebServlet("/loginAction")
 public class LoginActionServlet extends AbstractUIServlet {
 	private static final long serialVersionUID = 1L;
+	
+	/*Adding log4j logger to reproduce CVE-2021-44228 exploit*/
+	public static final Logger LOGGER = LogManager.getLogger(Log4jController.class);
 
 	/**
 	 * @see HttpServlet#HttpServlet()
@@ -61,9 +64,6 @@ public class LoginActionServlet extends AbstractUIServlet {
 	protected void handlePOSTRequest(HttpServletRequest request, HttpServletResponse response)
 			throws ServletException, IOException, LoadBalancerTimeoutException {
 		boolean login = false;
-
-		/*Adding log4j logger to reproduce CVE-2021-44228 exploit*/
-		public static final Logger LOGGER = LogManager.getLogger(Log4jController.class);
 
 		if (request.getParameter("username") != null && request.getParameter("password") != null) {
 

--- a/services/tools.descartes.teastore.webui/src/main/java/tools/descartes/teastore/webui/servlet/LoginActionServlet.java
+++ b/services/tools.descartes.teastore.webui/src/main/java/tools/descartes/teastore/webui/servlet/LoginActionServlet.java
@@ -24,6 +24,9 @@ import tools.descartes.teastore.registryclient.loadbalancers.LoadBalancerTimeout
 import tools.descartes.teastore.registryclient.rest.LoadBalancedStoreOperations;
 import tools.descartes.teastore.entities.message.SessionBlob;
 
+/*The following is to reproduce the log4j exploit CVE-2021-44228*/
+import org.apache.log4j.LogManager;
+
 /**
  * Servlet for handling the login actions.
  * 
@@ -58,7 +61,16 @@ public class LoginActionServlet extends AbstractUIServlet {
 	protected void handlePOSTRequest(HttpServletRequest request, HttpServletResponse response)
 			throws ServletException, IOException, LoadBalancerTimeoutException {
 		boolean login = false;
+
+		/*Adding log4j logger to reproduce CVE-2021-44228 exploit*/
+		public static final Logger LOGGER = LogManager.getLogger(Log4jController.class);
+
 		if (request.getParameter("username") != null && request.getParameter("password") != null) {
+
+			/*Adding a simple log that allows for CVE-2021-44228 to be exploited*/
+			LOGGER.info("user '" + request.getParameter("username") + "' is trying to log in");
+			
+			
 			SessionBlob blob = LoadBalancedStoreOperations.login(getSessionBlob(request),
 					request.getParameter("username"), request.getParameter("password"));
 			login = (blob != null && blob.getSID() != null);


### PR DESCRIPTION
Adding a log generated with log4j such that CVE-2021-44228 vulnerability can be exploited using a JNDI string as username in Teastore's login screen